### PR TITLE
Fix title & map parsing

### DIFF
--- a/modules/providers/wayCommand.lua
+++ b/modules/providers/wayCommand.lua
@@ -106,7 +106,7 @@ function PinProvider:ParseWayStringToData(wayString)
     -- iterate reverse over tokens to find the first number
     for idx = #tokens, 1, -1 do
         -- check if token is a number or a number with a decimal separator (check for different separators) else add the token to the title
-        if (type(tonumber(tokens[idx]) == "number") or string.find(tokens[idx], "%d" .. decimal_separator .. "%d")) then
+        if (type(tonumber(tokens[idx]))== "number" or string.find(tokens[idx], "%d" .. decimal_separator .. "%d")) then
             break
         else
             table.insert(titleTokens, 1, tokens[idx])


### PR DESCRIPTION
Issue: Waypont doesn't recognise Map id

bug: wrong check - was checking again always true condition, aka "type of boolean == true"

Solution: check the type string against `"number"`

Test case:
Be outside of the map pin zone, ex. Stormwind
```
/way #71 62.8 50.2 Bodadormu
```

Before:
![image](https://github.com/user-attachments/assets/90449e20-d7c3-4af3-be79-65b2387b7926)
![image](https://github.com/user-attachments/assets/233816ce-d491-4ad7-8660-e26c3733b930)
**As well as defaulting to current zone instead of the zone from the ID provided**

After:
![image](https://github.com/user-attachments/assets/968ec886-b335-41ac-a5b8-a3af58ce7c63)

